### PR TITLE
chore(repo): travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+install:
+  - pip install tox
+script:
+  - tox
+env:
+  - TOXENV=py27
+  - TOXENV=py34
+  - TOXENV=flake8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chessboard
+# Chessboard [![Build Status](https://travis-ci.org/checkmate/chessboard.png)](https://travis-ci.org/checkmate/chessboard)
 
 ## Overview
 


### PR DESCRIPTION
Adds .travis.yml and status icon to README.md header.