### PR TITLE
chore(repo): follow OpenStack hacking style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,8 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 * All features or bug fixes **must be tested** by one or more tests.
 * All modues and methods **must be documented**.
-* All code must pass **PEP-8, PEP-257, and flake8** checks with any exceptions explicitely noted and justified.
+* All code must pass **PEP-8, PEP-257, flake8** checks with any exceptions explicitly noted and justified.
+* Follow the OpenStack Hacking Guidelines as documented in [HACKING.rst][hacking] and automated in our style tests using the `hacking` module.
 
 ## <a name="commit"></a> Git Commit Guidelines
 
@@ -173,3 +174,5 @@ Note: inspired by and lifted with gratitude from [AngularJS](http://www.angularj
 [checkmate-hackers]: https://groups.google.com/forum/#!forum/checkmate-hackers
 [github]: https://github.com/checkmate/chessboard
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
+[hacking]: HACKING.rst
+

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,0 +1,58 @@
+OpenStack Style Commandments
+============================
+
+- Step 1: Read the OpenStack Style Commandments
+  http://docs.openstack.org/developer/hacking/
+- Step 2: Read on
+
+General
+-------
+- thou shalt not violate causality in our time cone, or else
+
+Docstrings
+----------
+
+Docstrings should ONLY use triple-double-quotes (``"""``)
+
+Single-line docstrings should NEVER have extraneous whitespace
+between enclosing triple-double-quotes.
+
+Deviation! Sentence fragments do not have punctuation.  Specifically in the
+command classes the one line docstring is also the help string for that
+command and those do not have periods.
+
+  """A one line docstring looks like this"""
+
+Calling Methods
+---------------
+
+Deviation! When breaking up method calls due to the 79 char line length limit,
+use the alternate 4 space indent.  With the first argument on the succeeding
+line all arguments will then be vertically aligned.  Use the same convention
+used with other data structure literals and terminate the method call with
+the last argument line ending with a comma and the closing paren on its own
+line indented to the starting line level.
+
+    unnecessarily_long_function_name(
+        'string one',
+        'string two',
+        kwarg1=constants.ACTIVE,
+        kwarg2=['a', 'b', 'c'],
+    )
+
+Python 3.x Compatibility
+------------------------
+
+Chessboard strives to be Python 3.4 compatible.  Common guidelines:
+
+* Convert print statements to functions: print statements should be converted
+  to an appropriate log or other output mechanism.
+* Use six where applicable: x.iteritems is converted to six.iteritems(x)
+  for example.
+
+Running Tests
+-------------
+
+The testing system is based on a combination of tox and nose. If you just
+want to run the whole suite, run `tox` and all will be fine.
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,6 @@
-nose
+# hacking is picky with its requirements, so let's have it run first.
+hacking            # requires flake8==2.2.4,pep8==1.5.7
+
 coverage
-flake8
 flake8_docstrings
+nose


### PR DESCRIPTION
In an attempt (probably futile) to minimize the
time spent on bike-shedding, we’ll use the
OpenStack python style guidelines which also come
with a flake8 plugin that can automatically detect
style errors.