### PR TITLE
Checkmatefile parser and schema definition, part 1

### DIFF
--- a/chessboard/parser.py
+++ b/chessboard/parser.py
@@ -1,0 +1,124 @@
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkmatefile parsing utilities.
+
+Uses validation in :mod:`chessboard.schema` to validate inputs.
+"""
+
+import six
+import voluptuous as volup
+import yaml
+
+from chessboard import schema as cb_schema
+
+
+class MultiValidationError(Exception):
+
+    """Basically a re-imagining of a `voluptuous.MultipleInvalid` error.
+
+    Reformats multiple errors messages for easy debugging of invalid
+    Checkmatefiles.
+    """
+
+    def __init__(self, errors):
+        """MultiValidationError constructor.
+
+        :param errors:
+            List of `voluptuous.Invalid` or `voluptuous.MultipleInvalid`
+            exception objects.
+        """
+        self.errors = errors
+        self.message = self._generate_message()
+
+    def __str__(self):
+        """Just return the pre-computed message.
+
+        See :meth:`_generate_message`.
+        """
+        return self.message
+
+    def __repr__(self):
+        """Simple representation of the exception, with the full message."""
+        indented_message = '\n'.join(
+            sorted('\t' + x for x in self.message.split('\n'))
+        )
+        return (
+            '%(cls_name)s(\n%(message)s\n)'
+            % dict(cls_name=self.__class__.__name__, message=indented_message)
+        )
+
+    def _generate_message(self):
+        """Reformat `path` attributes of each `error` and create a new message.
+
+        Join `path` attributes together in a more readable way, to enable easy
+        debugging of an invalid Checkmatefile.
+
+        :returns:
+            Reformatted error paths and messages, as a multi-line string.
+        """
+        reformatted_paths = (
+            ''.join(
+                "[%s]" % str(x)
+                # If it's not a string, don't put quotes around it. We do this,
+                # for example, when the value is an int, in the case of a list
+                # index.
+                if isinstance(x, six.integer_types)
+                # Otherwise, assume the path node is a string and put quotes
+                # around the key name, as if we were drilling down into a
+                # nested dict.
+                else "['%s']" % str(x)
+                for x in error.path
+            )
+            for error in self.errors
+        )
+
+        messages = (error.msg for error in self.errors)
+        # combine each path with its message:
+        zipped = zip(reformatted_paths, messages)
+        combined_messages = (
+            '%(path)s: %(messages)s' % dict(path=path, messages=message)
+            for path, message in zipped
+        )
+
+        return '\n'.join(sorted(combined_messages))
+
+
+def load(fileobj, schema=cb_schema.CHECKMATEFILE_SCHEMA):
+    """Load and validate a Checkmatefile.
+
+    Read the Checkmatefile and validate the syntax of the file per the
+    defined Checkmatefile schema, then return the Checkmatefile contents as a
+    `dict`.
+
+    :param fileobj:
+        A file-like with the contents of the Checkmatefile, in YAML format.
+    :param schema:
+        A callable into which the loaded Checkmatefile contents are passed (as
+        a dict, not as raw YAML). The callable should return the validated
+        contents, or raise exceptions.
+
+    :returns:
+        Checkmatefile contents as a `dict`.
+    """
+    contents = fileobj.read()
+    data = yaml.safe_load(contents)
+
+    # Validate the contents per the checkmatefile schema
+    try:
+        # NOTE(larsbutler): Voluptuous schema validators can mutate data, so we
+        # need to return whatever the schema validator gives us.
+        return schema(data)
+    except volup.MultipleInvalid as exc:
+        raise MultiValidationError(exc.errors)

--- a/chessboard/schema.py
+++ b/chessboard/schema.py
@@ -1,0 +1,239 @@
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schema definition and validation utils for the Checkmatefile structure."""
+
+import voluptuous as volup
+
+###########################
+# Constants and utilities #
+###########################
+
+INTERFACE_TYPES = [
+    'dns_tcp',
+    'dns_udp',
+    'ftp',
+    'gluster',
+    'host',
+    'http',
+    'https',
+    'imaps',
+    'imapv2',
+    'imapv3',
+    'imapv4',
+    'ldap',
+    'ldaps',
+    'linux',
+    'memcache',
+    'mongodb',
+    'mssql',
+    'mysql',
+    'new-relic',
+    'nfs',
+    'php',
+    'pop3',
+    'pop3s',
+    'postgres',
+    'proxy',
+    'rackspace-cloud-monitoring',
+    'rdp',
+    'redis',
+    'sftp',
+    'smtp',
+    'ssh',
+    'tcp',
+    'tcp_client_first',
+    'tcp_stream',
+    'udp',
+    'udp_stream',
+    'url',
+    'varnish',
+    'vip',
+    'windows',
+]
+
+RESOURCE_TYPES = [
+    'application',
+    'cache',
+    'compute',
+    'database',
+    'database-replica',
+    'directory',
+    'dns',
+    'object-store',
+    'host',
+    'key-pair',
+    'logging',
+    'load-balancer',
+    'mail-relay',
+    'web',
+    'monitoring',
+    'storage',
+    'volume',
+]
+
+
+def DictOf(schema):
+    """Validate that all values in a dict adhere to the supplied schema.
+
+    This allows schemas with a dictionary structure to be defined, where there
+    are specific constraints on the value, but no constraints on the key name.
+
+    Shamelessly copied from Checkmate and modified.
+    """
+    def check(entry):
+        if not isinstance(entry, dict):
+            raise volup.Invalid('value not a dict')
+        errors = []
+        for key, value in entry.items():
+            try:
+                schema(value)
+            except volup.MultipleInvalid as exc:
+                # Since the key can be arbitrary, we need to include it in the
+                # path so the error can be traced to a specific location.
+                for each in exc.errors:
+                    each.path.insert(0, key)
+                errors.extend(exc.errors)
+        if errors:
+            raise volup.MultipleInvalid(errors)
+        return entry
+    return check
+
+
+def Coerce(type, msg=None):
+    """Coerce a value to a type.
+
+    If the type constructor throws a ValueError, the value will be marked as
+    Invalid.
+
+    Shamelessly copied from the voluptuous docs:
+    https://github.com/alecthomas/voluptuous/blob/master/README.md
+    """
+    def f(v):
+        try:
+            return type(v)
+        except ValueError:
+            raise volup.Invalid(msg or ('expected %s' % type.__name__))
+    return f
+
+
+######################
+# Schema definitions #
+######################
+
+
+#: Schema for a member of
+#:  `blueprint` -> `services` -> SERVICE_NAME -> `relations`
+RELATION_SCHEMA = volup.Schema({
+    # TODO(larsbutler): This is the "long form" of relation schema.
+    # We need to also define the short form.
+    # Short form is just a single entry in a dict in the following format:
+    #   {<service>: <interface>} or {<service>: <interface>#<tag>}
+    #
+    #   where:
+    #       - <service> is the `service` name and expands to `service` in the
+    #         long form
+    #       - <interface> is a valid interface type and expands to `interface`
+    #         in the long form
+    #       - <tag> is an arbitrary label on the interface of another service.
+    #         we use tag in the case where another service defines multiple
+    #         interfaces with the same type; this tag is used to differentiate
+    #         them. Expands to `connect-from` in the long form.
+    #         TODO(larsbutler): Why is it `connect-from`, and not `connect-to`?
+    #         It seems backwards.
+    volup.Required('service'): str,
+    volup.Required('interface'): volup.Any('*', *INTERFACE_TYPES),
+
+    # FIXME(larsbutler): Need a better description for all of these.
+    # "source connection point name"
+    volup.Optional('connect-from'): str,
+    # The combination of resource type, interface, and tag is called a
+    # "target connection point name"
+    volup.Optional('connect-to'): str,
+    # FIXME(larsbutler): Need more detailed schema for these:
+    volup.Optional('constraints'): list,
+    volup.Optional('attributes'): dict,
+})
+
+# TODO(larsbutler): This is the "long form" of constraint structure.
+# We need to define the "short form" which is:
+#   {<setting>: <value>}, where <setting> is the `setting` name and <value> is
+#   the `value`.
+CONSTRAINT_SCHEMA = volup.Schema({
+    volup.Required('setting'): str,
+    # FIXME(larsbutler): Per a conversation with @ziadsawalha, `value` is
+    # supposed to be required, but it's not. I've seen examples of "valid"
+    # Checkmatefiles where this is missing.
+    volup.Optional('value'): volup.Any(bool, float, int, str),
+    volup.Optional('message'): str,
+    # Optional constraint operators:
+    volup.Optional('greater-than'): Coerce(str),
+    volup.Optional('less-than'): Coerce(str),
+    volup.Optional('greater-than-or-equal-to'): Coerce(str),
+    volup.Optional('less-than-or-equal-to'): Coerce(str),
+    volup.Optional('min-length'): int,
+    volup.Optional('max-length'): int,
+    volup.Optional('allowed-chars'): Coerce(str),
+    volup.Optional('required-chars'): Coerce(str),
+    volup.Optional('in'): list,
+    volup.Optional('protocols'): list,
+    volup.Optional('regex'): str,
+})
+
+
+#: Schema for a member of `blueprint` -> `services`
+SERVICE_SCHEMA = volup.Schema({
+    volup.Required('component'): volup.Schema({
+        volup.Required('interface'): volup.Any('*', *INTERFACE_TYPES),
+        volup.Required('resource_type'): volup.Any('*', *RESOURCE_TYPES),
+        volup.Optional('role'): str,
+        volup.Optional('name'): str,
+        volup.Optional('constraints'): [dict],
+    }),
+    # TODO(larsbutler): need to be more specific
+    volup.Optional('relations'): [RELATION_SCHEMA],
+    volup.Optional('constraints'): [CONSTRAINT_SCHEMA],
+    volup.Optional('display-name'): str,
+})
+
+
+#: Schema for `blueprint`
+BLUEPRINT_SCHEMA = volup.Schema({
+    volup.Required('id'): str,
+    volup.Required('name'): str,
+    volup.Required('services'): DictOf(SERVICE_SCHEMA),
+    volup.Required('version'): str,
+    volup.Optional('description'): str,
+    # The `source` field would (most likely) never be written by a blueprint
+    # author directly.
+    # These are only used if a blueprint is pulled from a remote source, and it
+    # purely metadata. These attributes do not affect the behavior of the
+    # blueprint.
+    # If we are working in the checkmate UI, for example, and we pull in a
+    # Checkmatefile from a remote repo, these fields will get populated. These
+    # are useful, then, if copies are made/modified from this Checkmatefile so
+    # we can trace the origin.
+    volup.Optional('source'): {
+        volup.Required('repo-url'): str,
+        volup.Required('sha'): str,
+        # master, another branch name, tag, etc.
+        volup.Optional('ref'): str,
+    },
+})
+
+#: Top level Checkmatefile schema
+CHECKMATEFILE_SCHEMA = volup.Schema({
+    volup.Required('blueprint'): BLUEPRINT_SCHEMA,
+    # TODO(larsbutler): Add the other sections, like `environment` and `inputs`
+})

--- a/chessboard/tests/__init__.py
+++ b/chessboard/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Chessboard tests go in this package."""

--- a/chessboard/tests/test_parser.py
+++ b/chessboard/tests/test_parser.py
@@ -1,0 +1,65 @@
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the :mod:`chessboard.parser` module."""
+
+import unittest
+
+import six
+import voluptuous as volup
+
+from chessboard import parser
+
+
+class TestMultiValidationError(unittest.TestCase):
+
+    """Tests for :class:`chessboard.parser.MultiValidationError`.
+
+    Mostly, we need to tests the formatting of error messages.
+    """
+
+    def test_error_formatting(self):
+        """Test the formatting of error paths."""
+        schema = volup.Schema({
+            volup.Required('blueprint'): volup.Schema({
+                volup.Required('id'): str,
+                volup.Required('name'): str,
+                volup.Optional('description'): str,
+            }),
+        })
+
+        fileobj = six.StringIO("""
+            blueprint:
+                id: def456
+            inputs: {}""")
+
+        expected_repr = """\
+MultiValidationError(
+\t['blueprint']['name']: required key not provided
+\t['inputs']: extra keys not allowed
+)"""
+        expected_str = """\
+['blueprint']['name']: required key not provided
+['inputs']: extra keys not allowed"""
+
+        expected_message = (
+            "['blueprint']['name']: required key not provided\n"
+            "['inputs']: extra keys not allowed"
+        )
+        with self.assertRaises(parser.MultiValidationError) as mve:
+            parser.load(fileobj, schema=schema)
+
+        self.assertEqual(expected_str, str(mve.exception))
+        self.assertEqual(expected_repr, repr(mve.exception))
+        self.assertEqual(expected_message, mve.exception.message)

--- a/chessboard/tests/test_schema.py
+++ b/chessboard/tests/test_schema.py
@@ -1,0 +1,220 @@
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the :mod:`chessboard.schema` module."""
+
+import unittest
+
+import six
+import voluptuous as volup
+import yaml
+
+from chessboard import parser
+from chessboard import schema as cb_schema
+
+
+class TestDictOf(unittest.TestCase):
+
+    """Tests for :func:`chessboard.schema.DictOf`."""
+
+    def setUp(self):
+        """For these tests, we create a simple but realstic schema."""
+        component_schema = volup.Schema({
+            volup.Required('interface'): str,
+            volup.Required('type'): str,
+        })
+        service_schema = volup.Schema({
+            volup.Required('component'): component_schema,
+            volup.Optional('relations'): [dict],
+        })
+        blueprint_schema = volup.Schema({
+            volup.Required('services'): cb_schema.DictOf(service_schema),
+        })
+        self.schema = volup.Schema({
+            volup.Required('blueprint'): blueprint_schema,
+        })
+
+    def test_valid(self):
+        """Test validation against a valid input."""
+        content = yaml.safe_load("""
+            blueprint:
+              services:
+                comp1:
+                  component:
+                    interface: http
+                    type: bar
+                  relations:
+                  - comp2: http
+                  - comp3: http
+                comp2:
+                  component:
+                    interface: http
+                    type: baz""")
+        # The validation simply returns the input value
+        output = self.schema(content)
+        self.assertEqual(output, content)
+
+    def test_invalid_missing_required(self):
+        """Test validation when missing a required element."""
+        content = yaml.safe_load("""
+            blueprint:
+              services:
+                comp1:
+                  component:
+                    interface: http
+                    type: bar
+                  relations:
+                  - comp2: http
+                  - comp3: http
+                comp2:
+                  component:
+                    interface: http
+                    type: baz
+                comp3:
+                  # comp3 is missing a `component` key
+                  relations:
+                  - comp2: http""")
+        with self.assertRaises(volup.MultipleInvalid) as mi:
+            self.schema(content)
+
+        expected_path = ['blueprint', 'services', 'comp3', 'component']
+        # Some of the `path` elements may look like strings, but are actually
+        # `voluptuous.Required` types; hence the map(str, ...).
+        self.assertListEqual(expected_path,
+                             [str(x) for x in mi.exception.path])
+
+    def test_invalid_not_a_dict(self):
+        """Test validation when the data is a list, not a dict.
+
+        In this test, we've turned `services` into a list, instead of a dict.
+        The schema requires that it is a dict of services, so we should get
+        an error on this.
+        """
+        content = yaml.safe_load("""
+            blueprint:
+              services:
+                - comp1:
+                  component:
+                    interface: http
+                    type: bar
+                  relations:
+                  - comp2: http
+                  - comp3: http
+                - comp2:
+                  component:
+                    interface: http
+                    type: baz""")
+        with self.assertRaises(volup.MultipleInvalid) as mi:
+            self.schema(content)
+
+        expected_path = ['blueprint', 'services']
+        self.assertListEqual(expected_path,
+                             [str(x) for x in mi.exception.path])
+
+
+class TestCheckmatefileSchema(unittest.TestCase):
+
+    """Main tests for the Checkmatefile schema definition."""
+
+    def test_valid(self):
+        """Test a simple but realistic Checkmatefile against the schema."""
+        fileobj = six.StringIO("""
+            blueprint:
+              id: 8363F2D2284D4871BC618E92D152994F
+              name: "magentostack-cloud"
+              description: "Magento install with Cloud Databases."
+              version: 1.0.0
+              services:
+                lb:
+                  component:
+                    interface: http
+                    resource_type: load-balancer
+                    constraints:
+                    - algorithm: ROUND_ROBIN
+                  relations:
+                  - service: magento
+                    interface: http
+                  - service: magento-worker
+                    interface: http
+                  display-name: Load Balancer
+                'magento':
+                  component:
+                    name: magento
+                    resource_type: application
+                    interface: http
+                    role: master
+                  constraints:
+                  - setting: count
+                    value: 1
+                  - setting: resource_type
+                    value: compute
+                  - setting: disk
+                    value: 50
+                'magento-worker':
+                  component:
+                    name: magento
+                    resource_type: application
+                    interface: http
+                    role: worker
+                  constraints:
+                  - setting: count  # used for manual scaling
+                    greater-than-or-equal-to: 0
+                    less-than: 9
+                  - setting: resource_type
+                    value: compute
+                  - setting: disk
+                    value: 50""")
+        parser.load(fileobj, schema=cb_schema.CHECKMATEFILE_SCHEMA)
+
+    def test_invalid(self):
+        """Test an extremely simple invalid blueprint."""
+        fileobj = six.StringIO("""
+            blueprint: {}
+            test: asfsfas""")
+        with self.assertRaises(parser.MultiValidationError) as mve:
+            parser.load(fileobj, schema=cb_schema.CHECKMATEFILE_SCHEMA)
+
+        expected_message = """\
+['blueprint']['id']: required key not provided
+['blueprint']['name']: required key not provided
+['blueprint']['services']: required key not provided
+['blueprint']['version']: required key not provided
+['test']: extra keys not allowed"""
+        self.assertEqual(expected_message, mve.exception.message)
+
+    def test_numeric_blueprint_id_not_allowed(self):
+        """Numeric blueprint id value are not allowed.
+
+        The reason for this is because the number may be converted in
+        unexpected ways:
+
+        100 -> "100"
+        0100 -> "64"
+        0x0 -> "0"
+        """
+        invalid_ids = ["100", "0100", "0x0"]
+
+        for invalid_id in invalid_ids:
+            fileobj = six.StringIO("""
+                blueprint:
+                  id: %(invalid_id)s
+                  name: test
+                  services: {}
+                  version: 0.0.1""" % dict(invalid_id=invalid_id))
+
+            with self.assertRaises(parser.MultiValidationError) as mve:
+                parser.load(fileobj, schema=cb_schema.CHECKMATEFILE_SCHEMA)
+
+            self.assertEqual("['blueprint']['id']: expected str",
+                             str(mve.exception))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml
+six
+voluptuous

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ hacking            # requires flake8==2.2.4,pep8==1.5.7
 coverage
 flake8_docstrings
 nose
+nose-ignore-docstring

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ envlist = py27,py34,style,docs
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=chessboard
+commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=chessboard \
+    --with-ignore-docstrings
 
 [testenv:style]
 # We use flake8 with the docstrings (pep257) plugin


### PR DESCRIPTION
Update: <strike>This needs some fixes. Please don't merge yet.</strike> Okay, ready to go.

Partially addresses https://github.com/checkmate/chessboard/issues/7.

This change adds the first iteration of Checkmatefile schema parsing and validation. There are tons of TODOs and FIXMEs in the code to give hints about what needs to be done next. 

In particular, we need to add schema definition and handling for the "long form" of things like `relations` and `options`.

Test coverage is near-perfect: 97% (missing two lines).