### PR TITLE
chore(.gitignore): ignore docs/_build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .coverage
 .tox
 chessboard.egg-info
+docs/_build


### PR DESCRIPTION
docs/_build is built by the `docs` tox config. The contents should never
be committed into git.