### PR TITLE
fix(tox.ini): reinstate --with-ignore-docstrings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ envlist = py27,py34,style,docs
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=chessboard
+commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=chessboard \
+    --with-ignore-docstrings
 
 [testenv:style]
 # We use flake8 with the docstrings (pep257) plugin


### PR DESCRIPTION
Reverts a change to tox.ini from
592ad662f4cf0d6210f8a0cb8b31de21643e982f. Basically, the change made the
verbose output of nosetests pretty much useless.